### PR TITLE
Add support for hpcc-nagios-monitoring

### DIFF
--- a/config_hpcc.sh
+++ b/config_hpcc.sh
@@ -82,7 +82,7 @@ then
       do
          ${SCRIPT_DIR}/get_ips.sh
          ${SCRIPT_DIR}/get_ips.py
-         [ $? -eq 0 ] && break  
+         [ $? -eq 0 ] && break
          trials=$(expr $trials \- 1)
          sleep 5
       done

--- a/hpcc/el6/Dockerfile.template.nagios.ce
+++ b/hpcc/el6/Dockerfile.template.nagios.ce
@@ -1,0 +1,42 @@
+FROM hpccsystems/linux:el6_<BASE_SUFFIX>
+
+# based on work done by Xiaoming Wang <xiaoming.wang@lexisnexis.com>
+MAINTAINER Gleb Aronsky <gleb.aronsky@lexisnexis.com>
+
+RUN yum update -y
+RUN yum install -y  net-tools which
+RUN chmod u+s $(which ping)
+
+# hpcc
+RUN wget <URL_BASE>/<PLATFORM_TYPE>-Candidate-<VERSION>/bin/platform/hpccsystems-platform-community_<FILE_NAME_SUFFIX>
+
+# hpcc-nagios
+RUN wget <URL_BASE>/<PLATFORM_TYPE>-Candidate-<VERSION>/bin/nagios-monitoring/hpccsystems-nagios-monitoring-<FILE_NAME_SUFFIX>
+
+RUN yum install httpd php php-cli gcc glibc glibc-common gd gd-devel net-snmp openssl-devel wget unzip make -y
+
+RUN groupadd hpcc
+RUN useradd -s /bin/bash -r -m -d /home/hpcc -g hpcc -c "hpcc Runtime User" hpcc
+RUN useradd nagios
+RUN groupadd nagcmd
+RUN usermod -a -G nagcmd nagios
+RUN usermod -a -G nagcmd apache
+RUN cd /tmp && wget https://assets.nagios.com/downloads/nagioscore/releases/nagios-4.1.1.tar.gz && wget http://www.nagios-plugins.org/download/nagios-plugins-2.1.1.tar.gz && tar zxf nagios-4.1.1.tar.gz && tar zxf nagios-plugins-2.1.1.tar.gz
+RUN cd /tmp/nagios-4.1.1 && ./configure --with-command-group=nagcmd --with-nagios-user=nagios --with-nagios-group=nagios --with-openssl && make all && make install && make install-init && make install-config && make install-commandmode && make install-webconf && htpasswd -c /usr/local/nagios/etc/htpasswd.users nagiosadmin && cd /tmp/nagios-plugins-2.1.1 && ./configure --with-nagios-user=nagios --with-nagios-group=nagios --with-openssl && make all && make install
+RUN yum install --nogpgcheck -y hpccsystems-platform-community_<FILE_NAME_SUFFIX>
+RUN yum install --nogpgcheck -y  --skip-broken hpccsystems-nagios-monitoring-<FILE_NAME_SUFFIX>
+EXPOSE 8010 8002 8015 9876
+RUN htpasswd -b -c /usr/local/nagios/etc/htpasswd.users nagiosadmin admin
+ADD run_master.sh /tmp/
+ADD config_hpcc.sh /tmp/
+ADD get_ips.sh /tmp/
+ADD get_ips.py /tmp/
+RUN chmod +x /tmp/run_master.sh
+RUN chmod +x /tmp/config_hpcc.sh
+RUN chmod +x /tmp/get_ips.sh
+RUN chmod +x /tmp/get_ips.py
+RUN mkdir -p /var/run/sshd
+RUN service httpd start
+RUN service nagios start
+RUN apachectl start
+CMD ["bash", "-c",  "/usr/sbin/sshd -D"]

--- a/hpcc/xenial/Dockerfile.template.nagios.ce
+++ b/hpcc/xenial/Dockerfile.template.nagios.ce
@@ -1,0 +1,38 @@
+FROM hpccsystems/linux:xenial_<BASE_SUFFIX>
+
+# based on work done by Xiaoming Wang <xiaoming.wang@lexisnexis.com>
+MAINTAINER Gleb Aronsky <gleb.aronsky@lexisnexis.com>
+
+RUN echo "postfix postfix/main_mailer_type string 'No Mail'" | debconf-set-selections
+RUN echo "postfix postfix/mailname string hpccsystems.com" | debconf-set-selections
+
+RUN echo "nagios3-cgi nagios3/adminpassword string nagiosadmin" | debconf-set-selections
+RUN echo "nagios3-cgi nagios3/adminpassword-repeat string nagiosadmin" | debconf-set-selections
+
+#RUN sudo rm -rf /var/lib/apt/lists/*
+
+#ADD libtiff5_4.0.6-1_amd64.deb /tmp/
+#RUN dpkg -i /tmp/libtiff5_4.0.6-1_amd64.deb
+RUN apt-get update
+RUN apt-get install -y -q libtiff5
+RUN apt-get install --fix-missing -y -q apache2 libapache2-mod-php build-essential libgd2-xpm-dev nagios-plugins nagios3 nagios-nrpe-plugin
+RUN wget <URL_BASE>/<PLATFORM_TYPE>-Candidate-<VERSION>/bin/platform/hpccsystems-platform-community_<FILE_NAME_SUFFIX>
+
+# hpcc-nagios
+RUN wget <URL_BASE>/<PLATFORM_TYPE>-Candidate-<VERSION>/bin/nagios-monitoring/hpccsystems-nagios-monitoring-<FILE_NAME_SUFFIX>
+
+RUN groupadd hpcc
+RUN useradd -s /bin/bash -r -m -d /home/hpcc -g hpcc -c "hpcc Runtime User" hpcc
+RUN dpkg -i hpccsystems-platform-community_<FILE_NAME_SUFFIX>
+RUN dpkg -i hpccsystems-nagios-monitoring-<FILE_NAME_SUFFIX>
+EXPOSE 8010 8002 8015 9876 80
+ADD run_master.sh /tmp/
+ADD config_hpcc.sh /tmp/
+ADD get_ips.py /tmp/
+ADD get_ips.sh /tmp/
+RUN chmod +x /tmp/run_master.sh
+RUN chmod +x /tmp/config_hpcc.sh
+RUN chmod +x /tmp/get_ips.py
+RUN chmod +x /tmp/get_ips.sh
+RUN mkdir -p /var/run/sshd
+CMD ["bash", "-c", "sudo /usr/sbin/sshd -D"]

--- a/start_hpcc.sh
+++ b/start_hpcc.sh
@@ -19,4 +19,3 @@ if [ -z "$1" ] || [ "$1" != "-x" ]
 then
    while [ 1 ] ; do sleep 60; done
 fi
-


### PR DESCRIPTION
Only Ubunut 16.04 xenial and CentOS 6 are supported.
CentOS 6 will build nagios from source
Ubuntu 16.04 will use apt-get to install nagios

Signed-off-by: Gleb Aronsky <gleb.aronsky@lexisnexis.com>